### PR TITLE
Update readme.txt to reflect latest tested version.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: patrickgarman
 Donate Link: https://www.paypal.me/pmgarman
 Tags: gosquared, analytics, woocommerce
 Requires at least: 4.0.0
-Tested up to: 4.4.2
+Tested up to: 4.8.2
 Stable tag: 4.3
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
Hi Patrick, 

I'm Russ and a Sales Engineer at GoSquared.  We've been made aware by a few newer users now that a warning notice is appearing indicating that the plugin has not been tested on the more current versions of Wordpress.

We've tested on 4.82 so just wanted to reflect this on the Readme.txt 

Would it be possible to publish again?